### PR TITLE
Comment adding `Content-Length` in header

### DIFF
--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -15,7 +15,8 @@ export const postRequest = (
   return new Promise((resolve, reject) => {
     const ops = { ...options } // clone
     const headers = ops.headers || {}
-    headers["Content-Length"] = data ? Buffer.byteLength(data) : 0
+    // Not allowed to set Content-Length in electron v7.1.2 and later on
+    // headers["Content-Length"] = data ? Buffer.byteLength(data) : 0
     headers["Content-Type"] = "application/x-www-form-urlencoded"
 
     const request = net.request({ ...ops, headers, method: "POST" })


### PR DESCRIPTION
Electron later version's not allowed to set `Content-Length` in headers